### PR TITLE
Update patient mapping and questionnaire for improved data handling

### DIFF
--- a/resources/seeds/Mapping/patient.yaml
+++ b/resources/seeds/Mapping/patient.yaml
@@ -47,13 +47,22 @@ body:
                   - "{% if %selfIdentifiedGender.exists() %}":
                       url: "comment"
                       valueString: "{{ %selfIdentifiedGender }}"
-          - "{% if %countryOfBirth.exists() %}":
+          - "{% if %birthPlace.exists() %}":
               - url: "http://hl7.org/fhir/StructureDefinition/patient-birthPlace"
                 valueAddress:
-                  text: "{{ %countryOfBirth }}"
+                  text: "{{ %birthPlace }}"
           - "{% if %indigenousStatus.exists() %}":
               - url: "http://hl7.org.au/fhir/StructureDefinition/indigenous-status"
-                valueCoding: "{{ %indigenousStatus }}"
+                valueCoding: 
+                  '{% assign %}':
+                    displayValue:
+                      - "{% if %indigenousStatus.code = '1' %}": Aboriginal but not Torres Strait Islander origin
+                      - "{% if %indigenousStatus.code = '2' %}": Torres Strait Islander but not Aboriginal origin
+                      - "{% if %indigenousStatus.code = '3' %}": Both Aboriginal and Torres Strait Islander origin
+                      - "{% if %indigenousStatus.code = '4' %}": Neither Aboriginal nor Torres Strait Islander origin
+                  code: '{{ %indigenousStatus.code }}'
+                  system: '{{ %indigenousStatus.system }}'
+                  display: '{{ %displayValue }}'
         "{% if %maritalStatus.exists() %}":
           maritalStatus: 
             coding:
@@ -69,12 +78,12 @@ body:
     - middleName: "{{ %QuestionnaireResponse.answers('middle-name') }}"
     - lastName: "{{ %QuestionnaireResponse.answers('last-name') }}"
     - title: "{{ %QuestionnaireResponse.answers('title') }}"
-    - gender: "{{ %QuestionnaireResponse.answers('sex') }}"
+    - gender: "{{ %QuestionnaireResponse.answers('gender') }}"
     - genderIdentity: "{{ %QuestionnaireResponse.answers('gender-identity') }}"
     - selfIdentifiedGender: "{{ %QuestionnaireResponse.answers('self-identified-gender') }}"
     - birthDate: "{{ %QuestionnaireResponse.answers('birthdate') }}"
     - maritalStatus: "{{ %QuestionnaireResponse.answers('marital-status') }}"
-    - countryOfBirth: "{{ %QuestionnaireResponse.answers('country-of-birth') }}"
+    - birthPlace: "{{ %QuestionnaireResponse.answers('birth-place') }}"
     - indigenousStatus: "{{ %QuestionnaireResponse.answers('indigenous-status') }}"
     - medicareNumber: "{{ %QuestionnaireResponse.answers('medicare-number') }}"
     - medicalRecordNumber: "{{ %QuestionnaireResponse.answers('patient-record-number') }}"

--- a/resources/seeds/Questionnaire/patient.yaml
+++ b/resources/seeds/Questionnaire/patient.yaml
@@ -30,6 +30,9 @@ item:
       expression: "%Patient.id"
 
   - linkId: patient-info-group
+    code:
+      - system: https://interrai.org/
+        code: iA1
     text: 1. Name
     type: group
     item:
@@ -84,14 +87,14 @@ item:
           language: text/fhirpath
           expression: "%Patient.name.prefix.first()"
 
-  - linkId: sex-group
+  - linkId: gender-group
     code:
       - system: https://interrai.org/
         code: iA2
     text: 2. Sex / Gender identity
     type: group
     item:
-      - linkId: sex
+      - linkId: gender
         code:
           - system: https://interrai.org/
             code: iA2c
@@ -101,7 +104,7 @@ item:
         initialExpression:
           language: text/fhirpath
           expression: |-
-            %Questionnaire.repeat(item).where(linkId='sex').answerOption.valueCoding.where(
+            %Questionnaire.repeat(item).where(linkId='gender').answerOption.valueCoding.where(
               code=iif(%Patient.gender='male' or %Patient.gender='female', %Patient.gender, 'other')
             )
         answerOption:
@@ -220,7 +223,7 @@ item:
     text: 5. Ethnicity and race
     type: group
     item:
-      - linkId: country-of-birth
+      - linkId: birth-place
         code:
         - system: https://interrai.org/
           code: iA45     
@@ -243,7 +246,12 @@ item:
             - code: inline-choice
         initialExpression:
               language: text/fhirpath
-              expression: "%Patient.extension('http://hl7.org.au/fhir/StructureDefinition/indigenous-status').valueCoding"
+              expression: |
+                %Questionnaire.repeat(item).where(
+                  linkId='indigenous-status'
+                ).answerOption.valueCoding.where(
+                  code=%Patient.extension('http://hl7.org.au/fhir/StructureDefinition/indigenous-status').valueCoding.code
+                )
         answerOption:
           - valueCoding:
               code: '1'


### PR DESCRIPTION
- Renamed linkId in the questionnaire and mapping for better terminology
- Changed `country-of-birth` to `birth-place` for more accurate field naming
- Enhanced `indigenous status` mapping with proper display values and coding structure
- Added missing `iA1` code to patient-info-group in questionnaire
- Improved initial expressions for `gender` and `indigenous` status fields
- Updated mapping logic to handle `indigenous status` codes with proper display text